### PR TITLE
Docker Swarm

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ if you need to query any configurations in other roles or tasks.
         compose: *install
         engine: *install
         machine: *install
+        swarm: *install
 ```
 
 ## Support

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,6 +3,28 @@
   when:
   - docker_role.bootloader == 'grub'
 
+- name: reload systemd
+  systemd:
+    daemon_reload: true
+
+- name: (dis/en)able udev cleanup timer
+  service:
+    name: udev-cleanup.timer
+    enabled: "{{ docker_role.engine.present }}"
+  ignore_errors: "{{ not docker_role.engine.present }}"
+
+- name: (dis/en)able dockerd
+  service:
+    name: docker
+    enabled: "{{ docker_role.engine.present }}"
+    state: "{{ 'started' if docker_role.engine.present else 'stopped' }}"
+  # HACK to pass idempotency test in `unapply.yml`
+  # TODO remove when https://github.com/ansible/ansible/issues/31344 is fixed
+  register: result
+  changed_when: "result.changed and docker_role.engine.present"
+  retries: 4
+  delay: 5
+
 - name: reload dockerd
   service:
     name: docker

--- a/tasks/engine.yml
+++ b/tasks/engine.yml
@@ -32,7 +32,7 @@
       state: &directory
         "{{ 'directory' if docker_role.engine.present else 'absent' }}"
 
-  - name: customize docker systemd service
+  - name: allow systemd docker service to listen on configured hosts
     copy:
       dest: &conf_systemd
         /etc/systemd/system/docker.service.d/ansible-role-docker.conf
@@ -40,7 +40,19 @@
       mode: a=r,u+w
       owner: root
       src: docker-systemd.conf
-    notify: reload dockerd
+    notify:
+      - reload systemd
+      - reload dockerd
+    when: docker_role.engine.config.hosts|d(False)
+
+  - name: make dockerd listen in its default systemd-controlled socket
+    file:
+      path: *conf_systemd
+      state: absent
+    when: not docker_role.engine.config.hosts|d(False)
+    notify:
+      - reload systemd
+      - reload dockerd
 
   - name: create docker configuration folder
     file:
@@ -87,7 +99,9 @@
         /etc/systemd/journald.conf.d/ansible-role-docker.conf
       mode: a=r,u+w
       src: journald.conf.j2
-    notify: restart journald
+    notify:
+      - reload systemd
+      - restart journald
 
   # HACK https://groups.google.com/d/msg/nomad-tool/6L6QbL6QzY4/1r8uvvSlCAAJ
   - name: add udev cleanup systemd timer
@@ -97,6 +111,9 @@
       mode: u=rw,go=r
       owner: root
       src: udev-cleanup.timer
+    notify:
+      - reload systemd
+      - (dis/en)able udev cleanup timer
 
   - name: add udev cleanup systemd service
     copy:
@@ -105,26 +122,25 @@
       mode: u=rw,go=r
       owner: root
       src: udev-cleanup.service
+    notify:
+      - reload systemd
+      - (dis/en)able udev cleanup timer
 
 - name: remove specific configurations for docker engine
   file:
     path: "{{ item }}"
     state: absent
   loop:
-  - *conf_docker
-  - *conf_grub
-  - *conf_journald
-  - *conf_systemd
-  - *conf_udev_service
-  - *conf_udev_timer
+    - *conf_docker
+    - *conf_grub
+    - *conf_journald
+    - *conf_systemd
+    - *conf_udev_service
+    - *conf_udev_timer
   when:
-  - not docker_role.engine.present
-
-- name: (dis/en)able udev cleanup timer
-  service:
-    name: udev-cleanup.timer
-    enabled: &present_bool "{{ docker_role.engine.present }}"
-  ignore_errors: &absent_bool "{{ not docker_role.engine.present }}"
+    - not docker_role.engine.present
+  notify:
+    - reload systemd
 
 - name: (un)install apt key for the official docker repository
   apt_key:
@@ -142,27 +158,19 @@
 
 - name: (un)install docker-ce stable
   apt:
-    autoremove: *absent_bool
+    autoremove: "{{ not docker_role.engine.present }}"
     name: docker-ce
     state: &latest
       "{{ 'latest' if docker_role.engine.present else 'absent' }}"
-  notify: reload dockerd
+  notify:
+    - reload systemd
+    - (dis/en)able dockerd
 
-- name: (dis/en)able dockerd
-  service:
-    name: docker
-    enabled: *present_bool
-    state: "{{ 'started' if docker_role.engine.present else 'stopped' }}"
-  # HACK to pass idempotency test in `unapply.yml`
-  # TODO remove when https://github.com/ansible/ansible/issues/31344 is fixed
-  register: result
-  changed_when: "result.changed and docker_role.engine.present"
+- name: run any notified handlers
+  meta: flush_handlers
 
 - name: check docker is installed correctly
   command: docker --version
   changed_when: false
   when:
   - *when_present
-
-- name: run any notified handlers
-  meta: flush_handlers

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,18 @@
+- name: install basic harmless dependencies
+  package:
+    name:
+    - apt-transport-https
+    - gzip
+    - iproute2
+    - python{% if ansible_python.version.major == 3 %}3{% endif %}-pip
+    - tar
+    state: present
+
+# Just in case we're missing the default ipv4, as explained in
+# https://stackoverflow.com/a/50373356/1468388
+- name: refresh facts
+  setup:
+
 - name: get docker configuration
   set_fact:
     docker_role:
@@ -8,16 +23,8 @@
     var: docker_role
     verbosity: 1
 
-- name: install basic harmless dependencies
-  package:
-    name:
-    - apt-transport-https
-    - gzip
-    - python{% if ansible_python.version.major == 3 %}3{% endif %}-pip
-    - tar
-    state: latest
-
 - import_tasks: engine.yml
+- import_tasks: swarm/main.yml
 - import_tasks: app.yml
 - import_tasks: compose.yml
 - import_tasks: machine.yml

--- a/tasks/swarm/facts.yml
+++ b/tasks/swarm/facts.yml
@@ -1,0 +1,22 @@
+- name: obtain docker info
+  command: docker info --format {{ "{{json .}}"|quote }}
+  changed_when: false
+  register: docker_info
+
+- name: obtain swarm manager join command
+  command: docker swarm join-token manager
+  register: join_manager
+  changed_when: false
+  failed_when: false
+
+- name: obtain swarm worker join command
+  command: docker swarm join-token worker
+  register: join_worker
+  changed_when: false
+  failed_when: false
+
+- name: process docker facts
+  set_fact:
+    docker_info: "{{ docker_info.stdout|from_json }}"
+    join_manager: "{{ join_manager.stdout_lines[2]|d('')|trim }}"
+    join_worker: "{{ join_worker.stdout_lines[2]|d('')|trim }}"

--- a/tasks/swarm/leave.yml
+++ b/tasks/swarm/leave.yml
@@ -1,0 +1,5 @@
+- name: leave swarm
+  command: docker swarm leave --force
+  register: stdout
+  changed_when: "'Node left the swarm.' in result.stdout"
+  failed_when: false

--- a/tasks/swarm/main.yml
+++ b/tasks/swarm/main.yml
@@ -1,0 +1,10 @@
+- import_tasks: present.yml
+  when:
+    - docker_role.engine.present
+    - docker_role.swarm.present
+
+- import_tasks: leave.yml
+  when:
+    # If engine is absent, the swarm should already be absent
+    - docker_role.engine.present
+    - not docker_role.swarm.present

--- a/tasks/swarm/present.yml
+++ b/tasks/swarm/present.yml
@@ -1,0 +1,118 @@
+- name: get swarm host lists
+  set_fact:
+    manager_hosts:
+      "{{ query('inventory_hostnames', docker_role.swarm.managers) }}"
+    worker_hosts:
+      "{{ query('inventory_hostnames', docker_role.swarm.workers) }}"
+
+- name: get hosts that are both managers and workers
+  set_fact:
+    repeated_hosts: "{{ manager_hosts|intersect(worker_hosts) }}"
+
+- name: ensure no host is defined as manager and worker
+  assert:
+    that: not repeated_hosts
+    msg: >
+      Found some hosts ({{ repeated_hosts|join(", ") }}) that are configured
+      both as swarm managers and workers because they match both patterns
+      ({{ docker_role.swarm.managers }} and {{ docker_role.swarm.workers }}).
+      Fix that and retry. Aborting.
+
+- import_tasks: facts.yml
+
+- name: get all cluster ids
+  set_fact:
+    swarm_clusters: "{{
+      swarm_clusters|d([])|
+      union([hostvars[item].docker_info.Swarm.Cluster.ID|d('')])
+    }}"
+  loop: "{{ manager_hosts }}"
+  when: "'Cluster' in hostvars[item].docker_info.Swarm"
+
+- name: get unique manager cluster ids
+  set_fact:
+    swarm_clusters: "{{ swarm_clusters|d([])|unique|difference(['']) }}"
+
+- name: ensure we are not working with several clusters
+  assert:
+    that: swarm_clusters|length < 2
+    msg: >
+      Swarm managers belong to {{ swarm_clusters|length }} different clusters.
+      There should be only only zero or one swarm clusters involved
+      between all the hosts that match the specified pattern
+      ({{ docker_role.swarm.managers }}), or otherwise I cannot know to which
+      cluster must I join the other nodes! Fix that and retry. Aborting.
+
+- name: init a new docker swarm
+  command: >
+    docker swarm init --advertise-addr
+    {{ docker_role.swarm.advertise_address|quote }}
+  when:
+    - not swarm_clusters
+    - &first inventory_hostname == manager_hosts|first
+
+- import_tasks: facts.yml
+
+- name: share necessary swarm facts
+  set_fact:
+    join_manager: "{{ join_manager or hostvars[item].join_manager }}"
+    join_worker: "{{ join_worker or hostvars[item].join_worker }}"
+    expected_manager:
+      "{{ expected_manager|d('') or hostvars[item].docker_info.Swarm.NodeID }}"
+  loop: "{{ manager_hosts }}"
+
+- name: leave alien swarms
+  import_tasks: leave.yml
+  when:
+    - docker_info.Swarm.LocalNodeState == 'active'
+    - docker_info.Swarm.NodeID != expected_manager
+    - expected_manager not in
+      docker_info.Swarm.RemoteManagers|map(attribute='NodeID')
+
+- name: get swarm join command for managers
+  set_fact:
+    join_command: "{{ join_manager }}"
+  when:
+    - inventory_hostname in manager_hosts
+    - docker_info.Swarm.LocalNodeState == 'inactive'
+
+- name: get swarm join command for workers
+  set_fact:
+    join_command: "{{ join_worker }}"
+  when:
+    - inventory_hostname in worker_hosts
+    - docker_info.Swarm.LocalNodeState == 'inactive'
+
+- name: join docker swarm
+  command: "{{ join_command }}"
+  register: result
+  changed_when: "'This node joined a swarm' in result.stdout"
+  when:
+    - join_command is defined
+
+- import_tasks: facts.yml
+
+- name: list swarm nodes
+  command: docker node ls --quiet
+  register: swarm_nodes
+  changed_when: false
+  when:
+    - docker_info.Swarm.ControlAvailable
+
+- name: promote swarm managers
+  command: docker node promote {{ item.0 }}
+  register: result
+  changed_when: "'promoted' in result.stdout"
+  loop: "{{ query('nested', swarm_nodes.stdout_lines, manager_hosts) }}"
+  when:
+    - docker_info.Swarm.ControlAvailable
+    - item.0 == hostvars[item.1].docker_info.Swarm.NodeID
+
+- name: demote swarm workers
+  command: docker node demote {{ item.0 }}
+  register: result
+  changed_when: "'demoted' in result.stdout"
+  loop: "{{ query('nested', swarm_nodes.stdout_lines, worker_hosts) }}"
+  when:
+    - docker_info.Swarm.ControlAvailable
+    - item.0 == hostvars[item.1].docker_info.Swarm.NodeID

--- a/tests/apply.yml
+++ b/tests/apply.yml
@@ -8,12 +8,19 @@
   - role: ../..
     vars:
       docker_role_custom:
-        app: &install {present: true}
+        app:
+          present: true
         bootloader: false
-        compose: *install
+        compose:
+          present: true
         engine:
           present: true
           config:
             # overlay2 driver fails inside containers
             storage-driver: vfs
-        machine: *install
+        machine:
+          present: true
+        swarm:
+          present: true
+          managers: "{{ swarm_managers_pattern }}"
+          workers: "{{ swarm_workers_pattern }}"

--- a/tests/inventory.cfg
+++ b/tests/inventory.cfg
@@ -1,9 +1,44 @@
+# Create the testing playground from this host
 [test-playground-controller]
 localhost ansible_connection=local
 
-[test-playground]
+# The staging swarm has just one manager and one worker
+[swarm-staging-manager]
+manager0
+
+[swarm-staging-worker]
 worker0
-worker1 ansible_python_interpreter=python2
+
+[swarm-staging:children]
+swarm-staging-manager
+swarm-staging-worker
+
+[swarm-staging:vars]
+ansible_python_interpreter=python2
+# See `apply.yml` to know how these variables are used
+swarm_managers_pattern=swarm-staging-manager
+swarm_workers_pattern=swarm-staging-worker
+
+# The production swarm has 3 managers and 2 workers
+[swarm-production-manager]
+manager[1:3]
+
+[swarm-production-worker]
+worker[1:2]
+
+[swarm-production:children]
+swarm-production-manager
+swarm-production-worker
+
+[swarm-production:vars]
+# See `apply.yml` to know how these variables are used
+swarm_managers_pattern=swarm-production-manager
+swarm_workers_pattern=swarm-production-worker
+
+# Define hosts to be created by the test playground
+[test-playground:children]
+swarm-staging
+swarm-production
 
 [all:vars]
 ansible_python_interpreter=python3

--- a/tests/unapply.yml
+++ b/tests/unapply.yml
@@ -13,3 +13,4 @@
         compose: *uninstall
         engine: *uninstall
         machine: *uninstall
+        swarm: *uninstall

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -42,3 +42,14 @@ docker_role_defaults:
       aarch64: 94d3846deaed2df4135824e2968dc64254e51d6431ca50c20f193b78e9683e5a
       armhf: 59764aeb9fb729931693736b8f15a67f4867b89bd242979b89d029f5946eeca5
       x86_64: 44c5c62db13b6eb6a9d3e276c1181401c78327ff6303570936ba2cf5d137b7b5
+
+  swarm:
+    # Define the {IP/interface}[:port] where to listen for swarm nodes
+    advertise_address: "{{ ansible_default_ipv4.address|d('eth0') }}"
+
+    present: true
+
+    # These are ansible host patterns that match a swarm;
+    # see `tests/inventory.cfg` as an example to have more than 1 swarm
+    managers: swarm-manager
+    workers: swarm-worker

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -20,9 +20,6 @@ docker_role_defaults:
   engine:
     # See https://docs.docker.com/engine/reference/commandline/dockerd/
     config:
-      group: admin # Let all sudoers to use docker without sudo
-      hosts:
-      - fd:// # Systemd docker socket
       icc: false
       log-driver: journald
       storage-driver: overlay2


### PR DESCRIPTION
- Disable default overriding of systemd configuration.
- Enable swarm, by default.
- Allow to have more than 1 swarm in your inventory.